### PR TITLE
feat: migrate schedule to use Scheduler::Schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Serverless Framework v2.32.0 or later is required.
          - [Enabling / Disabling](#enabling--disabling)
          - [Specify Name and Description](#specify-name-and-description)
          - [Scheduled Events IAM Role](#scheduled-events-iam-role)
-         - [Specify InputTransformer](#specify-inputtransformer)
+         - [Specify Scheduler Options](#specify-scheduler-options)
      - [CloudWatch Event](#cloudwatch-event)
          - [Simple event definition](#simple-event-definition)
          - [Enabling / Disabling](#enabling--disabling-1)
@@ -934,7 +934,7 @@ Clients connecting to this Rest API will then need to set any of these API keys 
 
 ### Schedule
 
-The following config will attach a schedule event and causes the stateMachine `crawl` to be called every 2 hours. The configuration allows you to attach multiple schedules to the same stateMachine. You can either use the `rate` or `cron` syntax. Take a look at the [AWS schedule syntax documentation](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html) for more details.
+The following config will attach a schedule event and causes the stateMachine `crawl` to be called every 2 hours. The configuration allows you to attach multiple schedules to the same stateMachine. You can either use the `rate`, `cron`, or `at` syntax. Take a look at the [AWS schedule syntax documentation](https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html) for more details.
 
 ```yaml
 stepFunctions:
@@ -995,22 +995,26 @@ events:
       role: arn:aws:iam::xxxxxxxx:role/yourRole
 ```
 
-#### Specify InputTransformer
+#### Specify Scheduler Options
 
-You can specify input values ​​to the Lambda function.
+You can specify several EventBridge Scheduler options for the schedule:
+* start_date: date in UTC after which the schedule will begin
+* end_date: date in UTC on which the schedule will end
+* timezone: timezone for schedule, e.g. `America/New_York`
+* flex_time_window: time in minutes for a flexible start time after rate
+* group_name: name of existing schedule group
+* kms_key_arn: ARN for KMS key used to encrypt/decrypt scheduler data
 
 ```yml
 stepFunctions:
   stateMachines:
     stateMachineScheduled:
       events:
-        - schedule: 
+        - schedule:
             rate: cron(30 12 ? * 1-5 *)
-            inputTransformer:
-              inputPathsMap: 
-                time: '$.time'
-                stage: '$.stageVariables'
-              inputTemplate: '{"time": <time>, "stage" : <stage> }'
+            start_date: 2022-11-30
+            end_date: 2022-12-01
+            timezone: America/New_York
       definition:
         ...
 ```

--- a/lib/deploy/events/schedule/compileScheduledEvents.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.js
@@ -89,7 +89,6 @@ module.exports = {
               .getScheduleLogicalId(stateMachineName, scheduleNumberInFunction);
             const scheduleIamRoleLogicalId = this
               .getScheduleToStepFunctionsIamRoleLogicalId(stateMachineName);
-            const scheduleId = this.getScheduleId(stateMachineName);
             const policyName = this.getSchedulePolicyName(stateMachineName);
 
             const roleArn = event.schedule.role
@@ -120,12 +119,11 @@ module.exports = {
                   ${ScheduleExpressionTimezone ? `"ScheduleExpressionTimezone": "${ScheduleExpressionTimezone}",` : ''}
                   ${StartDate ? `"StartDate": "${StartDate}",` : ''}
                   "State": "${State}",
-                  "Targets": [{
+                  "Target": {
                     "Arn": { "Ref": "${stateMachineLogicalId}" },
                     ${Input ? `"Input": "${Input}",` : ''}
-                    "Id": "${scheduleId}",
                     "RoleArn": ${roleArn}
-                  }]
+                  }
                 }
               }
             `;

--- a/lib/deploy/events/schedule/compileScheduledEvents.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.js
@@ -14,14 +14,17 @@ module.exports = {
           if (event.schedule) {
             scheduleNumberInFunction++;
             let ScheduleExpression;
+            let ScheduleExpressionTimezone;
             let State;
             let Input;
-            let InputPath;
-            let InputTransformer;
-            let InputTemplate;
-            let InputPathsMap;
             let Name;
             let Description;
+            let EndDate;
+            let StartDate;
+            let FlexTimeWindowMode;
+            let MaximumWindowInMinutes;
+            let GroupName;
+            let KmsKeyArn;
 
             // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
@@ -36,27 +39,28 @@ module.exports = {
                   .Error(errorMessage);
               }
               ScheduleExpression = event.schedule.rate;
+              ScheduleExpressionTimezone = event.schedule.timezone;
+              EndDate = event.schedule.end_date;
+              StartDate = event.schedule.start_date;
+              GroupName = event.schedule.group_name;
+              KmsKeyArn = event.schedule.kms_key_arn;
+
+              FlexTimeWindowMode = 'OFF';
+
+              if (event.schedule.flex_time_window) {
+                FlexTimeWindowMode = 'FLEXIBLE';
+                MaximumWindowInMinutes = event.schedule.flex_time_window;
+              }
+
               State = 'ENABLED';
+
               if (event.schedule.enabled === false) {
                 State = 'DISABLED';
               }
+
               Input = event.schedule.input;
-              InputPath = event.schedule.inputPath;
-              InputTransformer = event.schedule.inputTransformer;
-              InputPathsMap = InputTransformer && event.schedule.inputTransformer.inputPathsMap;
-              InputTemplate = InputTransformer && event.schedule.inputTransformer.inputTemplate;
               Name = event.schedule.name;
               Description = event.schedule.description;
-
-              if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
-                const errorMessage = [
-                  'You can\'t set both input & inputPath properties at the',
-                  'same time for schedule events.',
-                  'Please check the AWS docs for more info',
-                ].join('');
-                throw new this.serverless.classes
-                  .Error(errorMessage);
-              }
 
               if (Input && typeof Input === 'object') {
                 Input = JSON.stringify(Input);
@@ -64,15 +68,6 @@ module.exports = {
               if (Input && typeof Input === 'string') {
                 // escape quotes to favor JSON.parse
                 Input = Input.replace(/\"/g, '\\"'); // eslint-disable-line
-              }
-              // no need to escape quotes in inputPathsMap
-              // because we add it as an object to the template
-              if (InputPathsMap && typeof InputPathsMap === 'object') {
-                InputPathsMap = JSON.stringify(InputPathsMap);
-              }
-              if (InputTemplate && typeof InputTemplate === 'string') {
-                // escape quotes to favor JSON.parse
-                InputTemplate = InputTemplate.replace(/\"/g, '\\"'); // eslint-disable-line
               }
             } else if (typeof event.schedule === 'string') {
               ScheduleExpression = event.schedule;
@@ -110,20 +105,24 @@ module.exports = {
 
             const scheduleTemplate = `
               {
-                "Type": "AWS::Events::Rule",
+                "Type": "AWS::Scheduler::Schedule",
                 "Properties": {
-                  "ScheduleExpression": "${ScheduleExpression}",
-                  "State": "${State}",
-                  ${Name ? `"Name": "${Name}",` : ''}
                   ${Description ? `"Description": "${Description}",` : ''}
+                  ${EndDate ? `"EndDate": "${EndDate}",` : ''}
+                  "FlexibleTimeWindow": {
+                    ${MaximumWindowInMinutes ? `"MaximumWindowInMinutes": ${MaximumWindowInMinutes},` : ''}
+                    "Mode": "${FlexTimeWindowMode}"
+                  },
+                  ${GroupName ? `"GroupName": "${GroupName}",` : ''}
+                  ${KmsKeyArn ? `"KmsKeyArn": "${KmsKeyArn}",` : ''}
+                  ${Name ? `"Name": "${Name}",` : ''}
+                  "ScheduleExpression": "${ScheduleExpression}",
+                  ${ScheduleExpressionTimezone ? `"ScheduleExpressionTimezone": "${ScheduleExpressionTimezone}",` : ''}
+                  ${StartDate ? `"StartDate": "${StartDate}",` : ''}
+                  "State": "${State}",
                   "Targets": [{
-                    ${Input ? `"Input": "${Input}",` : ''}
-                    ${InputPath ? `"InputPath": "${InputPath}",` : ''}
-                    ${InputTransformer ? `"InputTransformer": {
-                      "InputPathsMap": ${InputPathsMap},
-                      "InputTemplate": "${InputTemplate}"
-                    },` : ''}
                     "Arn": { "Ref": "${stateMachineLogicalId}" },
+                    ${Input ? `"Input": "${Input}",` : ''}
                     "Id": "${scheduleId}",
                     "RoleArn": ${roleArn}
                   }]
@@ -141,7 +140,7 @@ module.exports = {
                     {
                       "Effect": "Allow",
                       "Principal": {
-                        "Service": "events.amazonaws.com"
+                        "Service": "scheduler.amazonaws.com"
                       },
                       "Action": "sts:AssumeRole"
                     }

--- a/lib/deploy/events/schedule/compileScheduledEvents.test.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.test.js
@@ -384,7 +384,7 @@ describe('#httpValidate()', () => {
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstStepFunctionsSchedulerSchedule1
-        .Properties.Targets[0].Input).to.equal('{"key":"value"}');
+        .Properties.Target.Input).to.equal('{"key":"value"}');
     });
 
     it('should respect input variable as an object', () => {
@@ -411,7 +411,7 @@ describe('#httpValidate()', () => {
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstStepFunctionsSchedulerSchedule1
-        .Properties.Targets[0].Input).to.equal('{"key":"value"}');
+        .Properties.Target.Input).to.equal('{"key":"value"}');
     });
 
     it('should respect role variable', () => {
@@ -439,7 +439,7 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources.FirstStepFunctionsSchedulerSchedule1
-        .Properties.Targets[0].RoleArn).to.equal('arn:aws:iam::000000000000:role/test-role');
+        .Properties.Target.RoleArn).to.equal('arn:aws:iam::000000000000:role/test-role');
     });
 
     it('should not create corresponding resources when scheduled events are not given', () => {

--- a/lib/deploy/events/schedule/compileScheduledEvents.test.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.test.js
@@ -88,13 +88,13 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1.Type).to.equal('AWS::Events::Rule');
+        .FirstStepFunctionsSchedulerSchedule1.Type).to.equal('AWS::Scheduler::Schedule');
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule2.Type).to.equal('AWS::Events::Rule');
+        .FirstStepFunctionsSchedulerSchedule2.Type).to.equal('AWS::Scheduler::Schedule');
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule3.Type).to.equal('AWS::Events::Rule');
+        .FirstStepFunctionsSchedulerSchedule3.Type).to.equal('AWS::Scheduler::Schedule');
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
         .FirstScheduleToStepFunctionsRole.Type).to.equal('AWS::IAM::Role');
@@ -134,20 +134,82 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1
+        .FirstStepFunctionsSchedulerSchedule1
         .Properties.State).to.equal('DISABLED');
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule2
+        .FirstStepFunctionsSchedulerSchedule2
         .Properties.State).to.equal('ENABLED');
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule3
+        .FirstStepFunctionsSchedulerSchedule3
         .Properties.State).to.equal('ENABLED');
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule4
+        .FirstStepFunctionsSchedulerSchedule4
         .Properties.State).to.equal('ENABLED');
+    });
+
+    it('should respect flex_time_window variable, defaulting to OFF with no max window', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(10 minutes)',
+                },
+              },
+              {
+                schedule: {
+                  rate: 'cron(0 2 * * ? *)',
+                  flex_time_window: 15,
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileScheduledEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule1
+        .Properties.FlexibleTimeWindow.Mode).to.equal('OFF');
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule2
+        .Properties.FlexibleTimeWindow.Mode).to.equal('FLEXIBLE');
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule2
+        .Properties.FlexibleTimeWindow.MaximumWindowInMinutes).to.equal(15);
+    });
+
+    it('should respect timezone variable', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(10 minutes)',
+                  enabled: false,
+                  timezone: 'America/New_York',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileScheduledEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule1
+        .Properties.ScheduleExpressionTimezone).to.equal('America/New_York');
     });
 
     it('should respect name variable', () => {
@@ -171,7 +233,7 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1
+        .FirstStepFunctionsSchedulerSchedule1
         .Properties.Name).to.equal('your-scheduled-event-name');
     });
 
@@ -196,11 +258,11 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1
+        .FirstStepFunctionsSchedulerSchedule1
         .Properties.Description).to.equal('your scheduled event description');
     });
 
-    it('should respect inputPath variable', () => {
+    it('should respect end_date variable', () => {
       serverlessStepFunctions.serverless.service.stepFunctions = {
         stateMachines: {
           first: {
@@ -209,7 +271,7 @@ describe('#httpValidate()', () => {
                 schedule: {
                   rate: 'rate(10 minutes)',
                   enabled: false,
-                  inputPath: '$.stageVariables',
+                  end_date: '2023-01-01',
                 },
               },
             ],
@@ -221,8 +283,83 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1
-        .Properties.Targets[0].InputPath).to.equal('$.stageVariables');
+        .FirstStepFunctionsSchedulerSchedule1
+        .Properties.EndDate).to.equal('2023-01-01');
+    });
+
+    it('should respect start_date variable', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(10 minutes)',
+                  enabled: false,
+                  start_date: '2023-01-01',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileScheduledEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule1
+        .Properties.StartDate).to.equal('2023-01-01');
+    });
+
+    it('should respect group_name variable', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(10 minutes)',
+                  enabled: false,
+                  group_name: 'my group',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileScheduledEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule1
+        .Properties.GroupName).to.equal('my group');
+    });
+
+    it('should respect kms_key_arn variable', () => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                schedule: {
+                  rate: 'rate(10 minutes)',
+                  enabled: false,
+                  kms_key_arn: 'arn::kms::test',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileScheduledEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources
+        .FirstStepFunctionsSchedulerSchedule1
+        .Properties.KmsKeyArn).to.equal('arn::kms::test');
     });
 
     it('should respect input variable', () => {
@@ -246,7 +383,7 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1
+        .FirstStepFunctionsSchedulerSchedule1
         .Properties.Targets[0].Input).to.equal('{"key":"value"}');
     });
 
@@ -273,31 +410,8 @@ describe('#httpValidate()', () => {
 
       expect(serverlessStepFunctions.serverless.service
         .provider.compiledCloudFormationTemplate.Resources
-        .FirstStepFunctionsEventsRuleSchedule1
+        .FirstStepFunctionsSchedulerSchedule1
         .Properties.Targets[0].Input).to.equal('{"key":"value"}');
-    });
-
-    it('should throw an error when both Input and InputPath are set', () => {
-      serverlessStepFunctions.serverless.service.stepFunctions = {
-        stateMachines: {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'rate(10 minutes)',
-                  enabled: false,
-                  input: {
-                    key: 'value',
-                  },
-                  inputPath: '$.stageVariables',
-                },
-              },
-            ],
-          },
-        },
-      };
-
-      expect(() => serverlessStepFunctions.compileScheduledEvents()).to.throw(Error);
     });
 
     it('should respect role variable', () => {
@@ -324,7 +438,7 @@ describe('#httpValidate()', () => {
         .FirstScheduleToStepFunctionsRole).to.equal(undefined);
 
       expect(serverlessStepFunctions.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstStepFunctionsEventsRuleSchedule1
+        .provider.compiledCloudFormationTemplate.Resources.FirstStepFunctionsSchedulerSchedule1
         .Properties.Targets[0].RoleArn).to.equal('arn:aws:iam::000000000000:role/test-role');
     });
 
@@ -359,68 +473,6 @@ describe('#httpValidate()', () => {
         serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate
           .Resources,
       ).to.deep.equal({});
-    });
-
-
-    it('should respect inputTransformer variable', () => {
-      serverlessStepFunctions.serverless.service.stepFunctions = {
-        stateMachines: {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'rate(10 minutes)',
-                  enabled: false,
-                  inputTransformer: {
-                    inputPathsMap: {
-                      stage: '$.stageVariables',
-                    },
-                    inputTemplate: '{ "stage": <stage> }',
-                  },
-                },
-              },
-            ],
-          },
-        },
-      };
-
-      serverlessStepFunctions.compileScheduledEvents();
-
-      expect(serverlessStepFunctions.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstStepFunctionsEventsRuleSchedule1
-        .Properties.Targets[0].InputTransformer.InputPathsMap).to.have.property('stage', '$.stageVariables');
-      expect(serverlessStepFunctions.serverless.service
-        .provider.compiledCloudFormationTemplate.Resources.FirstStepFunctionsEventsRuleSchedule1
-        .Properties.Targets[0].InputTransformer.InputTemplate).to.equal('{ "stage": <stage> }');
-    });
-
-    it('should throw an error when Input and InputPath and InputTransformer are set', () => {
-      serverlessStepFunctions.serverless.service.stepFunctions = {
-        stateMachines: {
-          first: {
-            events: [
-              {
-                schedule: {
-                  rate: 'rate(10 minutes)',
-                  enabled: false,
-                  input: {
-                    key: 'value',
-                  },
-                  inputPath: '$.stageVariables',
-                  inputTransformer: {
-                    inputPathsMap: {
-                      stage: '$.stageVariables',
-                    },
-                    inputTemplate: '{ "stage": <stage> }',
-                  },
-                },
-              },
-            ],
-          },
-        },
-      };
-
-      expect(() => serverlessStepFunctions.compileScheduledEvents()).to.throw(Error);
     });
   });
 });

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -54,10 +54,6 @@ module.exports = {
   },
 
   // Schedule
-  getScheduleId(stateMachineName) {
-    return `${stateMachineName}StepFunctionsSchedule`;
-  },
-
   getScheduleLogicalId(stateMachineName, scheduleIndex) {
     return `${this.provider.naming
       .getNormalizedFunctionName(stateMachineName)}StepFunctionsSchedulerSchedule${scheduleIndex}`;

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -60,7 +60,7 @@ module.exports = {
 
   getScheduleLogicalId(stateMachineName, scheduleIndex) {
     return `${this.provider.naming
-      .getNormalizedFunctionName(stateMachineName)}StepFunctionsEventsRuleSchedule${scheduleIndex}`;
+      .getNormalizedFunctionName(stateMachineName)}StepFunctionsSchedulerSchedule${scheduleIndex}`;
   },
 
   getScheduleToStepFunctionsIamRoleLogicalId(stateMachineName) {

--- a/lib/naming.test.js
+++ b/lib/naming.test.js
@@ -127,7 +127,7 @@ describe('#naming', () => {
   describe('#getScheduleLogicalId()', () => {
     it('should normalize the stateMachine output name and add the standard suffix', () => {
       expect(serverlessStepFunctions.getScheduleLogicalId('stateMachine', 1)).to
-        .equal('StateMachineStepFunctionsEventsRuleSchedule1');
+        .equal('StateMachineStepFunctionsSchedulerSchedule1');
     });
   });
 


### PR DESCRIPTION
Migrate to the new AWS::Scheduler::Schedule resource instead of AWS::Events::Rule. I tested this out in 2 scenarios: 

1. Update serverless-step-functions version with existing state machine schedules. This deletes the old EventBridge Rule and creates a matching Schedule with the same cron, status, etc.
2. Use new functionality of Schedule resource by setting some of the new params: 
   * start_date
   * end_date
   * timezone
   * flex_time_window


![Screen Shot 2022-11-29 at 12 47 07 PM](https://user-images.githubusercontent.com/19270062/204605693-b931090c-1d8f-46fa-87a3-8f499015837b.png)
